### PR TITLE
manifest: Track clang 13.0.2

### DIFF
--- a/snippets/sakura.xml
+++ b/snippets/sakura.xml
@@ -53,7 +53,6 @@
   <project path="packages/services/Telecomm" name="packages_services_Telecomm" groups="pdk-cw-fs,pdk-fs" remote="sakura" />   
   <project path="packages/services/Telephony" name="LineageOS/android_packages_services_Telephony" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/Updater" name="packages_apps_Updater" remote="sakura" />     
-  <project path="prebuilts/clang/host/linux-x86/clang-proton" name="kdrag0n/proton-clang" remote="github" revision="master" clone-depth="1" />  
   <project path="prebuilts/prebuiltapks" name="prebuilts_prebuiltapks" remote="sakura" />
   <project path="system/core" name="system_core" groups="pdk" remote="sakura" />
   <project path="system/netd" name="system_netd" groups="pdk" remote="sakura" />  
@@ -62,5 +61,10 @@
   <project path="vendor/addons" name="vendor_addons" remote="sakura" />
   <project path="vendor/lineage" name="vendor_sakura" remote="sakura" />   
   <project path="vendor/gapps" name="LordShen/android_vendor_gapps" remote="gitlab" revision="11" clone-depth="1" />
+
+  <!-- Clang Proton -->
+  <project path="prebuilts/clang/host/linux-x86/clang-proton" name="kdrag0n/proton-clang" remote="github" revision="master" clone-depth="1" />  
+  <!-- Clang 13 version 13.0.2 -->
+  <project path="prebuilts/clang/host/linux-x86/clang-latest" name="crdroidandroid/android_prebuilts_clang_host_linux-x86_clang-r433403" remote="gitlab" revision="11.0" clone-depth="1" />
 
 </manifest>


### PR DESCRIPTION
* market name as clang-latest , from crDroid
* also moved clang proton in specific clang group

Signed-off-by: agustkid <agustkid@gmail.com>